### PR TITLE
Update copyright

### DIFF
--- a/container/karaf/distro/pom.xml
+++ b/container/karaf/distro/pom.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-    limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/container/karaf/distro/scripts/antrun-karaf-distro.xml
+++ b/container/karaf/distro/scripts/antrun-karaf-distro.xml
@@ -1,22 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  #%L
-  Gravia :: Container :: Karaf :: Patch
-  %%
   Copyright (C) 2010 - 2014 JBoss by Red Hat
-  %%
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
        http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
-  #L%
   -->
 <project default="build">
 

--- a/container/karaf/managed/pom.xml
+++ b/container/karaf/managed/pom.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-    limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/container/karaf/managed/src/main/java/io/fabric8/container/karaf/KarafContainerBuilder.java
+++ b/container/karaf/managed/src/main/java/io/fabric8/container/karaf/KarafContainerBuilder.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.container.karaf;
 

--- a/container/karaf/managed/src/main/java/io/fabric8/container/karaf/KarafContainerCreateHandler.java
+++ b/container/karaf/managed/src/main/java/io/fabric8/container/karaf/KarafContainerCreateHandler.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.container.karaf;
 

--- a/container/karaf/managed/src/main/java/io/fabric8/container/karaf/KarafCreateOptions.java
+++ b/container/karaf/managed/src/main/java/io/fabric8/container/karaf/KarafCreateOptions.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.container.karaf;
 

--- a/container/karaf/managed/src/main/java/io/fabric8/container/karaf/KarafManagedContainer.java
+++ b/container/karaf/managed/src/main/java/io/fabric8/container/karaf/KarafManagedContainer.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.container.karaf;
 

--- a/container/karaf/managed/src/main/java/io/fabric8/container/karaf/internal/KarafContainerActivator.java
+++ b/container/karaf/managed/src/main/java/io/fabric8/container/karaf/internal/KarafContainerActivator.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.container.karaf.internal;
 

--- a/container/karaf/managed/src/main/resources/io/fabric8/container/karaf/version.properties
+++ b/container/karaf/managed/src/main/resources/io/fabric8/container/karaf/version.properties
@@ -1,2 +1,17 @@
+#
+# Copyright (C) 2010 - 2014 JBoss by Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+#
+
 project.version=${project.version}
 karaf.version=${version.apache.karaf}

--- a/container/karaf/patch/etc/karaf/data/repository/environment.xml
+++ b/container/karaf/patch/etc/karaf/data/repository/environment.xml
@@ -1,22 +1,17 @@
 <?xml version="1.0" ?>
 <!--
-  #%L
-  Gravia :: Container :: Karaf :: Patch
-  %%
   Copyright (C) 2010 - 2014 JBoss by Red Hat
-  %%
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
        http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
-  #L%
   -->
 
 <repository xmlns="http://www.osgi.org/xmlns/repository/v1.0.0" name="EnvironmentContent">

--- a/container/karaf/patch/etc/karaf/etc/jetty.xml
+++ b/container/karaf/patch/etc/karaf/etc/jetty.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0"?>
+<!--
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  -->
+
 <!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//
 DTD Configure//EN" "http://jetty.mortbay.org/configure.dtd">
 

--- a/container/karaf/patch/pom.xml
+++ b/container/karaf/patch/pom.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-    limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/container/karaf/patch/scripts/antrun-karaf-patch.xml
+++ b/container/karaf/patch/scripts/antrun-karaf-patch.xml
@@ -1,22 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  #%L
-  Gravia :: Container :: Karaf :: Patch
-  %%
   Copyright (C) 2010 - 2014 JBoss by Red Hat
-  %%
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
        http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
-  #L%
   -->
 <project default="build">
 

--- a/container/karaf/patch/scripts/assembly-deploy-artifacts.xml
+++ b/container/karaf/patch/scripts/assembly-deploy-artifacts.xml
@@ -1,21 +1,16 @@
 <!--
-  #%L
-  Gravia :: Container :: Karaf :: Patch
-  %%
   Copyright (C) 2010 - 2014 JBoss by Red Hat
-  %%
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
        http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
-  #L%
   -->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/container/karaf/pom.xml
+++ b/container/karaf/pom.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-    limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/container/tomcat/distro/pom.xml
+++ b/container/tomcat/distro/pom.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-    limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/container/tomcat/distro/scripts/antrun-tomcat-distro.xml
+++ b/container/tomcat/distro/scripts/antrun-tomcat-distro.xml
@@ -1,22 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  #%L
-  Gravia :: Container :: Karaf :: Patch
-  %%
   Copyright (C) 2010 - 2014 JBoss by Red Hat
-  %%
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
        http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
-  #L%
   -->
 <project default="build">
 

--- a/container/tomcat/managed/pom.xml
+++ b/container/tomcat/managed/pom.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-    limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/container/tomcat/managed/src/main/java/io/fabric8/container/tomcat/TomcatContainerBuilder.java
+++ b/container/tomcat/managed/src/main/java/io/fabric8/container/tomcat/TomcatContainerBuilder.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.container.tomcat;
 

--- a/container/tomcat/managed/src/main/java/io/fabric8/container/tomcat/TomcatContainerCreateHandler.java
+++ b/container/tomcat/managed/src/main/java/io/fabric8/container/tomcat/TomcatContainerCreateHandler.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.container.tomcat;
 

--- a/container/tomcat/managed/src/main/java/io/fabric8/container/tomcat/TomcatCreateOptions.java
+++ b/container/tomcat/managed/src/main/java/io/fabric8/container/tomcat/TomcatCreateOptions.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.container.tomcat;
 

--- a/container/tomcat/managed/src/main/java/io/fabric8/container/tomcat/TomcatManagedContainer.java
+++ b/container/tomcat/managed/src/main/java/io/fabric8/container/tomcat/TomcatManagedContainer.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.container.tomcat;
 

--- a/container/tomcat/managed/src/main/java/io/fabric8/container/tomcat/internal/TomcatContainerActivator.java
+++ b/container/tomcat/managed/src/main/java/io/fabric8/container/tomcat/internal/TomcatContainerActivator.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.container.tomcat.internal;
 

--- a/container/tomcat/managed/src/main/resources/io/fabric8/container/tomcat/version.properties
+++ b/container/tomcat/managed/src/main/resources/io/fabric8/container/tomcat/version.properties
@@ -1,2 +1,17 @@
+#
+# Copyright (C) 2010 - 2014 JBoss by Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+#
+
 project.version=${project.version}
 tomcat.version=${apache.tomcat.version}

--- a/container/tomcat/patch/etc/tomcat/conf/tomcat-users.xml
+++ b/container/tomcat/patch/etc/tomcat/conf/tomcat-users.xml
@@ -1,22 +1,17 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
-  #%L
-  Gravia :: Integration Tests :: Tomcat
-  %%
   Copyright (C) 2010 - 2014 JBoss by Red Hat
-  %%
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
        http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
-  #L%
   -->
 
 <tomcat-users>

--- a/container/tomcat/patch/pom.xml
+++ b/container/tomcat/patch/pom.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-    limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/container/tomcat/patch/scripts/antrun-tomcat-patch.xml
+++ b/container/tomcat/patch/scripts/antrun-tomcat-patch.xml
@@ -1,5 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  -->
+
 <!-- ====================================================================== -->
 <!--                                                                        -->
 <!--  JBoss, the OpenSource J2EE webOS                                      -->

--- a/container/tomcat/patch/scripts/assembly-deploy-artifacts.xml
+++ b/container/tomcat/patch/scripts/assembly-deploy-artifacts.xml
@@ -1,3 +1,18 @@
+<!--
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">

--- a/container/tomcat/pom.xml
+++ b/container/tomcat/pom.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-    limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/container/tomcat/webapp/pom.xml
+++ b/container/tomcat/webapp/pom.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-    limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/container/tomcat/webapp/src/main/java/io/fabric8/container/tomcat/webapp/FabricBootstrapCompleteListener.java
+++ b/container/tomcat/webapp/src/main/java/io/fabric8/container/tomcat/webapp/FabricBootstrapCompleteListener.java
@@ -1,23 +1,16 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
- * Copyright (C) 2010 - 2013 JBoss by Red Hat
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
- * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  */
 package io.fabric8.container.tomcat.webapp;
 

--- a/container/tomcat/webapp/src/main/java/io/fabric8/container/tomcat/webapp/FabricPropertiesProvider.java
+++ b/container/tomcat/webapp/src/main/java/io/fabric8/container/tomcat/webapp/FabricPropertiesProvider.java
@@ -1,23 +1,16 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
- * Copyright (C) 2010 - 2013 JBoss by Red Hat
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
- * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  */
 package io.fabric8.container.tomcat.webapp;
 

--- a/container/tomcat/webapp/src/main/java/io/fabric8/container/tomcat/webapp/FabricServlet.java
+++ b/container/tomcat/webapp/src/main/java/io/fabric8/container/tomcat/webapp/FabricServlet.java
@@ -1,23 +1,16 @@
 /*
- * JBoss, Home of Professional Open Source.
- * Copyright 2010, Red Hat, Inc., and individual contributors
- * as indicated by the @author tags. See the copyright.txt file in the
- * distribution for a full listing of individual contributors.
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  */
 package io.fabric8.container.tomcat.webapp;
 

--- a/container/tomcat/webapp/src/main/java/io/fabric8/container/tomcat/webapp/FabricTomcatActivator.java
+++ b/container/tomcat/webapp/src/main/java/io/fabric8/container/tomcat/webapp/FabricTomcatActivator.java
@@ -1,23 +1,16 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
- * Copyright (C) 2010 - 2013 JBoss by Red Hat
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
- * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  */
 package io.fabric8.container.tomcat.webapp;
 

--- a/container/tomcat/webapp/src/main/java/io/fabric8/container/tomcat/webapp/SecurityActions.java
+++ b/container/tomcat/webapp/src/main/java/io/fabric8/container/tomcat/webapp/SecurityActions.java
@@ -1,23 +1,16 @@
 /*
- * #%L
- * JBossOSGi Framework
- * %%
- * Copyright (C) 2010 - 2012 JBoss by Red Hat
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
- * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  */
 package io.fabric8.container.tomcat.webapp;
 

--- a/container/tomcat/webapp/src/main/webapp/META-INF/context.xml
+++ b/container/tomcat/webapp/src/main/webapp/META-INF/context.xml
@@ -1,20 +1,18 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
-  Licensed to the Apache Software Foundation (ASF) under one or more
-  contributor license agreements.  See the NOTICE file distributed with
-  this work for additional information regarding copyright ownership.
-  The ASF licenses this file to You under the Apache License, Version 2.0
-  (the "License"); you may not use this file except in compliance with
-  the License.  You may obtain a copy of the License at
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
-      http://www.apache.org/licenses/LICENSE-2.0
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
--->
+  -->
 <Context>
     <Loader delegate="true"/>
 </Context>

--- a/container/tomcat/webapp/src/main/webapp/WEB-INF/branding.properties
+++ b/container/tomcat/webapp/src/main/webapp/WEB-INF/branding.properties
@@ -1,18 +1,16 @@
 #
-# Copyright (C) FuseSource, Inc.
-# http://fusesource.com
+# Copyright (C) 2010 - 2014 JBoss by Red Hat
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
 #
 
 welcome = \

--- a/container/tomcat/webapp/src/main/webapp/WEB-INF/classes/log4j.properties
+++ b/container/tomcat/webapp/src/main/webapp/WEB-INF/classes/log4j.properties
@@ -1,22 +1,17 @@
-###
-# #%L
-# Gravia :: Integration Tests :: Tomcat
-# %%
+#
 # Copyright (C) 2010 - 2014 JBoss by Red Hat
-# %%
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
-# #L%
-###
+#
 
 # Root logger option
 log4j.rootLogger=DEBUG, file

--- a/container/tomcat/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/container/tomcat/webapp/src/main/webapp/WEB-INF/web.xml
@@ -1,22 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-    
-    http://www.apache.org/licenses/LICENSE-2.0
-    
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
--->
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  -->
 <!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
     "http://java.sun.com/dtd/web-app_2_3.dtd">
 <web-app>

--- a/fabric/api/pom.xml
+++ b/fabric/api/pom.xml
@@ -1,18 +1,16 @@
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/fabric/api/src/main/java/io/fabric8/api/Attributable.java
+++ b/fabric/api/src/main/java/io/fabric8/api/Attributable.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/AttributableBuilder.java
+++ b/fabric/api/src/main/java/io/fabric8/api/AttributableBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/AttributeKey.java
+++ b/fabric/api/src/main/java/io/fabric8/api/AttributeKey.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ComponentEvent.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ComponentEvent.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ComponentEventListener.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ComponentEventListener.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ConfigurationProfileItem.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ConfigurationProfileItem.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ConfigurationProfileItemBuilder.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ConfigurationProfileItemBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/Constants.java
+++ b/fabric/api/src/main/java/io/fabric8/api/Constants.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/Container.java
+++ b/fabric/api/src/main/java/io/fabric8/api/Container.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ContainerBuilder.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ContainerBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ContainerIdentity.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ContainerIdentity.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ContainerManager.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ContainerManager.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ContainerManagerLocator.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ContainerManagerLocator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+
 package io.fabric8.api;
 
 /**

--- a/fabric/api/src/main/java/io/fabric8/api/CreateOptions.java
+++ b/fabric/api/src/main/java/io/fabric8/api/CreateOptions.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/CreateOptionsProvider.java
+++ b/fabric/api/src/main/java/io/fabric8/api/CreateOptionsProvider.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/FabricEvent.java
+++ b/fabric/api/src/main/java/io/fabric8/api/FabricEvent.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/FabricEventListener.java
+++ b/fabric/api/src/main/java/io/fabric8/api/FabricEventListener.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/FabricException.java
+++ b/fabric/api/src/main/java/io/fabric8/api/FabricException.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/Failure.java
+++ b/fabric/api/src/main/java/io/fabric8/api/Failure.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/Host.java
+++ b/fabric/api/src/main/java/io/fabric8/api/Host.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/HostIdentity.java
+++ b/fabric/api/src/main/java/io/fabric8/api/HostIdentity.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/Identifiable.java
+++ b/fabric/api/src/main/java/io/fabric8/api/Identifiable.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/Identity.java
+++ b/fabric/api/src/main/java/io/fabric8/api/Identity.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/JMXServiceEndpoint.java
+++ b/fabric/api/src/main/java/io/fabric8/api/JMXServiceEndpoint.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/JoinOptions.java
+++ b/fabric/api/src/main/java/io/fabric8/api/JoinOptions.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/LifecycleException.java
+++ b/fabric/api/src/main/java/io/fabric8/api/LifecycleException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+
 package io.fabric8.api;
 
 /**

--- a/fabric/api/src/main/java/io/fabric8/api/LinkedProfile.java
+++ b/fabric/api/src/main/java/io/fabric8/api/LinkedProfile.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/LinkedProfileVersion.java
+++ b/fabric/api/src/main/java/io/fabric8/api/LinkedProfileVersion.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/LockHandle.java
+++ b/fabric/api/src/main/java/io/fabric8/api/LockHandle.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/Profile.java
+++ b/fabric/api/src/main/java/io/fabric8/api/Profile.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileBuilder.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileBuilderFactory.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileBuilderFactory.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileEvent.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileEvent.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileEventListener.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileEventListener.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileIdentity.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileIdentity.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileItem.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileItem.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileItemBuilder.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileItemBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileManager.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileManager.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileManagerLocator.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileManagerLocator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+
 package io.fabric8.api;
 
 /**

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileOptionsProvider.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileOptionsProvider.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileVersion.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileVersion.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileVersionBuilder.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileVersionBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileVersionBuilderFactory.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileVersionBuilderFactory.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileVersionOptionsProvider.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileVersionOptionsProvider.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProvisionEvent.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProvisionEvent.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProvisionEventListener.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProvisionEventListener.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ResourceItem.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ResourceItem.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ServiceEndpoint.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ServiceEndpoint.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ServiceEndpointIdentity.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ServiceEndpointIdentity.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/ServiceLocator.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ServiceLocator.java
@@ -1,18 +1,16 @@
 /*
- * Copyright (C) FuseSource, Inc.
- *   http://fusesource.com
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  */
 package io.fabric8.api;
 

--- a/fabric/api/src/main/java/io/fabric8/api/management/ContainerManagement.java
+++ b/fabric/api/src/main/java/io/fabric8/api/management/ContainerManagement.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api.management;
 

--- a/fabric/api/src/main/java/io/fabric8/api/management/ProfileManagement.java
+++ b/fabric/api/src/main/java/io/fabric8/api/management/ProfileManagement.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api.management;
 

--- a/fabric/api/src/main/java/io/fabric8/api/management/ProfileVersionManagement.java
+++ b/fabric/api/src/main/java/io/fabric8/api/management/ProfileVersionManagement.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.api.management;
 

--- a/fabric/core/pom.xml
+++ b/fabric/core/pom.xml
@@ -1,18 +1,16 @@
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/fabric/core/src/main/java/io/fabric8/core/internal/BootstrapCompleteImpl.java
+++ b/fabric/core/src/main/java/io/fabric8/core/internal/BootstrapCompleteImpl.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.core.internal;
 

--- a/fabric/core/src/main/java/io/fabric8/core/internal/BootstrapService.java
+++ b/fabric/core/src/main/java/io/fabric8/core/internal/BootstrapService.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.core.internal;
 

--- a/fabric/core/src/main/java/io/fabric8/core/internal/ClusterDataStoreImpl.java
+++ b/fabric/core/src/main/java/io/fabric8/core/internal/ClusterDataStoreImpl.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.core.internal;
 

--- a/fabric/core/src/main/java/io/fabric8/core/internal/ConfigurationManager.java
+++ b/fabric/core/src/main/java/io/fabric8/core/internal/ConfigurationManager.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.core.internal;
 

--- a/fabric/core/src/main/java/io/fabric8/core/internal/ContainerRegistry.java
+++ b/fabric/core/src/main/java/io/fabric8/core/internal/ContainerRegistry.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.core.internal;
 

--- a/fabric/core/src/main/java/io/fabric8/core/internal/ContainerServiceImpl.java
+++ b/fabric/core/src/main/java/io/fabric8/core/internal/ContainerServiceImpl.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.core.internal;
 

--- a/fabric/core/src/main/java/io/fabric8/core/internal/EventDispatcherImpl.java
+++ b/fabric/core/src/main/java/io/fabric8/core/internal/EventDispatcherImpl.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.core.internal;
 

--- a/fabric/core/src/main/java/io/fabric8/core/internal/HostDataStoreImpl.java
+++ b/fabric/core/src/main/java/io/fabric8/core/internal/HostDataStoreImpl.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.core.internal;
 

--- a/fabric/core/src/main/java/io/fabric8/core/internal/ImmutableContainer.java
+++ b/fabric/core/src/main/java/io/fabric8/core/internal/ImmutableContainer.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.core.internal;
 

--- a/fabric/core/src/main/java/io/fabric8/core/internal/ImmutableProfile.java
+++ b/fabric/core/src/main/java/io/fabric8/core/internal/ImmutableProfile.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.core.internal;
 

--- a/fabric/core/src/main/java/io/fabric8/core/internal/ImmutableProfileVersion.java
+++ b/fabric/core/src/main/java/io/fabric8/core/internal/ImmutableProfileVersion.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.core.internal;
 

--- a/fabric/core/src/main/java/io/fabric8/core/internal/MBeansProvider.java
+++ b/fabric/core/src/main/java/io/fabric8/core/internal/MBeansProvider.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.core.internal;
 

--- a/fabric/core/src/main/java/io/fabric8/core/internal/PortManagerImpl.java
+++ b/fabric/core/src/main/java/io/fabric8/core/internal/PortManagerImpl.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.core.internal;
 

--- a/fabric/core/src/main/java/io/fabric8/core/internal/ProfileServiceImpl.java
+++ b/fabric/core/src/main/java/io/fabric8/core/internal/ProfileServiceImpl.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.core.internal;
 

--- a/fabric/pom.xml
+++ b/fabric/pom.xml
@@ -1,18 +1,16 @@
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/fabric/spi/pom.xml
+++ b/fabric/spi/pom.xml
@@ -1,18 +1,16 @@
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
   -->
 
 <!--

--- a/fabric/spi/src/main/java/io/fabric8/spi/AbstractAttributableBuilder.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/AbstractAttributableBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/AbstractContainerBuilder.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/AbstractContainerBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/AbstractContainerHandle.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/AbstractContainerHandle.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/AbstractCreateOptions.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/AbstractCreateOptions.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/AbstractJMXServiceEndpoint.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/AbstractJMXServiceEndpoint.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/AbstractManagedContainer.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/AbstractManagedContainer.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/AbstractManagedContainerBuilder.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/AbstractManagedContainerBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/AbstractManagedContainerHandle.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/AbstractManagedContainerHandle.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/AbstractManagedCreateOptions.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/AbstractManagedCreateOptions.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/AbstractProfileItem.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/AbstractProfileItem.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/AttributeSupport.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/AttributeSupport.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Resource
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/BootstrapComplete.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/BootstrapComplete.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+
 package io.fabric8.spi;
 
 /**

--- a/fabric/spi/src/main/java/io/fabric8/spi/ClusterDataStore.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/ClusterDataStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+
 package io.fabric8.spi;
 
 import io.fabric8.api.ContainerIdentity;

--- a/fabric/spi/src/main/java/io/fabric8/spi/ContainerCreateHandler.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/ContainerCreateHandler.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/ContainerHandle.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/ContainerHandle.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/ContainerService.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/ContainerService.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/DefaultContainerBuilder.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/DefaultContainerBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/DefaultContainerCreateHandler.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/DefaultContainerCreateHandler.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/DefaultCreateOptions.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/DefaultCreateOptions.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/EventDispatcher.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/EventDispatcher.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+
 package io.fabric8.spi;
 
 import io.fabric8.api.ComponentEvent;

--- a/fabric/spi/src/main/java/io/fabric8/spi/HostDataStore.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/HostDataStore.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+
 package io.fabric8.spi;
 
 import io.fabric8.api.ContainerIdentity;

--- a/fabric/spi/src/main/java/io/fabric8/spi/ManagedContainer.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/ManagedContainer.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/ManagedContainerBuilder.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/ManagedContainerBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/ManagedCreateOptions.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/ManagedCreateOptions.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/PortManager.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/PortManager.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+
 package io.fabric8.spi;
 
 import java.net.InetAddress;

--- a/fabric/spi/src/main/java/io/fabric8/spi/ProfileService.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/ProfileService.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/SystemProperties.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/SystemProperties.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.spi;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/internal/ContainerManagerImpl.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/internal/ContainerManagerImpl.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.internal;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/internal/DefaultConfigurationProfileItemBuilder.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/internal/DefaultConfigurationProfileItemBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.internal;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/internal/DefaultProfileBuilder.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/internal/DefaultProfileBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.internal;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/internal/DefaultProfileVersionBuilder.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/internal/DefaultProfileVersionBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.internal;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/internal/ProfileBuilderService.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/internal/ProfileBuilderService.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.internal;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/internal/ProfileManagerImpl.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/internal/ProfileManagerImpl.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.internal;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/internal/ProfileVersionBuilderService.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/internal/ProfileVersionBuilderService.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.internal;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/management/AttributesOpenType.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/management/AttributesOpenType.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Resource
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.management;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/management/ContainerOpenType.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/management/ContainerOpenType.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Resource
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.management;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/management/ProfileOpenType.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/management/ProfileOpenType.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Resource
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.management;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/management/ProfileVersionOpenType.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/management/ProfileVersionOpenType.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Resource
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.management;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/permit/DefaultPermitManager.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/permit/DefaultPermitManager.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Runtime :: API
- * %%
- * Copyright (C) 2013 - 2014 JBoss by Red Hat
- * %%
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.permit;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/permit/PermitKey.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/permit/PermitKey.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Runtime :: API
- * %%
- * Copyright (C) 2013 - 2014 JBoss by Red Hat
- * %%
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.permit;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/permit/PermitManager.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/permit/PermitManager.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Runtime :: API
- * %%
- * Copyright (C) 2013 - 2014 JBoss by Red Hat
- * %%
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.permit;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/permit/PermitManagerImpl.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/permit/PermitManagerImpl.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.permit;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/permit/PermitStateTimeoutException.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/permit/PermitStateTimeoutException.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Runtime :: API
- * %%
- * Copyright (C) 2013 - 2014 JBoss by Red Hat
- * %%
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.permit;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/scr/AbstractComponent.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/scr/AbstractComponent.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.spi.scr;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/scr/AbstractProtectedComponent.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/scr/AbstractProtectedComponent.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Integration Tests :: Common
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.scr;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/scr/InvalidComponentException.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/scr/InvalidComponentException.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.spi.scr;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/scr/Validatable.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/scr/Validatable.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.spi.scr;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/scr/ValidatingReference.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/scr/ValidatingReference.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.spi.scr;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/scr/ValidationSupport.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/scr/ValidationSupport.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.spi.scr;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/utils/IllegalStateAssertion.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/utils/IllegalStateAssertion.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Resource
- * %%
  * Copyright (C) 2010 - 2014 JBoss by Red Hat
- * %%
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.spi.utils;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/utils/ManagementUtils.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/utils/ManagementUtils.java
@@ -1,18 +1,16 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package io.fabric8.spi.utils;
 

--- a/fabric/spi/src/test/java/io/fabric8/test/spi/PermitManagerTest.java
+++ b/fabric/spi/src/test/java/io/fabric8/test/spi/PermitManagerTest.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Runtime :: Embedded
- * %%
- * Copyright (C) 2013 - 2014 JBoss by Red Hat
- * %%
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,8 +11,6 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
 package io.fabric8.test.spi;
 

--- a/fabric/spi/src/test/resources/logging.properties
+++ b/fabric/spi/src/test/resources/logging.properties
@@ -1,22 +1,17 @@
-###
-# #%L
-# Gravia :: Runtime :: Embedded
-# %%
-# Copyright (C) 2013 - 2014 JBoss by Red Hat
-# %%
+#
+# Copyright (C) 2010 - 2014 JBoss by Red Hat
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
-# #L%
-###
+#
 
 # Root logger option
 log4j.rootLogger=DEBUG, file

--- a/itests/basic/common/pom.xml
+++ b/itests/basic/common/pom.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-    limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/itests/basic/common/src/main/java/io/fabric8/test/basic/ManagedContainerLifecycleTests.java
+++ b/itests/basic/common/src/main/java/io/fabric8/test/basic/ManagedContainerLifecycleTests.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Runtime :: Embedded
- * %%
- * Copyright (C) 2013 - 2014 JBoss by Red Hat
- * %%
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,9 +11,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
+
 package io.fabric8.test.basic;
 
 

--- a/itests/basic/common/src/main/java/io/fabric8/test/basic/container/ManagedContainerLifecycleTest.java
+++ b/itests/basic/common/src/main/java/io/fabric8/test/basic/container/ManagedContainerLifecycleTest.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Runtime :: Embedded
- * %%
- * Copyright (C) 2013 - 2014 JBoss by Red Hat
- * %%
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,9 +11,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
+
 package io.fabric8.test.basic.container;
 
 

--- a/itests/basic/embedded/pom.xml
+++ b/itests/basic/embedded/pom.xml
@@ -1,18 +1,16 @@
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
   -->
 
 <!--

--- a/itests/basic/embedded/src/test/java/io/fabric8/test/basic/embedded/StandaloneManagedContainerTest.java
+++ b/itests/basic/embedded/src/test/java/io/fabric8/test/basic/embedded/StandaloneManagedContainerTest.java
@@ -1,19 +1,18 @@
-/**
- * Copyright (C) FuseSource, Inc.
- * http://fusesource.com
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
  */
+
 package io.fabric8.test.basic.embedded;
 
 import io.fabric8.api.management.ContainerManagement;

--- a/itests/basic/embedded/src/test/resources/gravia.properties
+++ b/itests/basic/embedded/src/test/resources/gravia.properties
@@ -1,22 +1,17 @@
-###
-# #%L
-# Gravia :: Runtime :: Embedded
-# %%
-# Copyright (C) 2013 - 2014 JBoss by Red Hat
-# %%
+#
+# Copyright (C) 2010 - 2014 JBoss by Red Hat
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
-# #L%
-###
+#
 
 org.jboss.gravia.runtime.storage=target/runtime
 org.jboss.gravia.runtime.storage.clean=onFirstInit

--- a/itests/basic/embedded/src/test/resources/logging.properties
+++ b/itests/basic/embedded/src/test/resources/logging.properties
@@ -1,22 +1,17 @@
-###
-# #%L
-# Gravia :: Runtime :: Embedded
-# %%
-# Copyright (C) 2013 - 2014 JBoss by Red Hat
-# %%
+#
+# Copyright (C) 2010 - 2014 JBoss by Red Hat
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
-# #L%
-###
+#
 
 # Root logger option
 log4j.rootLogger=DEBUG, file, console

--- a/itests/basic/karaf/pom.xml
+++ b/itests/basic/karaf/pom.xml
@@ -1,18 +1,16 @@
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
   -->
 
 <!--

--- a/itests/basic/karaf/src/test/resources/arquillian.xml
+++ b/itests/basic/karaf/src/test/resources/arquillian.xml
@@ -1,24 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  #%L
-  Gravia :: Integration Tests :: OSGi
-  %%
-  Copyright (C) 2010 - 2013 JBoss by Red Hat
-  %%
-  This program is free software: you can redistribute it and/or modify
-  it under the terms of the GNU Lesser General Public License as 
-  published by the Free Software Foundation, either version 2.1 of the 
-  License, or (at your option) any later version.
-  
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Lesser Public License for more details.
-  
-  You should have received a copy of the GNU General Lesser Public 
-  License along with this program.  If not, see
-  <http://www.gnu.org/licenses/lgpl-2.1.html>.
-  #L%
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
   -->
 
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/itests/basic/karaf/src/test/resources/logging.properties
+++ b/itests/basic/karaf/src/test/resources/logging.properties
@@ -1,24 +1,17 @@
-###
-# #%L
-# JBossOSGi Resolver API
-# %%
-# Copyright (C) 2010 - 2013 JBoss by Red Hat
-# %%
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as 
-# published by the Free Software Foundation, either version 2.1 of the 
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Lesser Public License for more details.
-# 
-# You should have received a copy of the GNU General Lesser Public 
-# License along with this program.  If not, see
-# <http://www.gnu.org/licenses/lgpl-2.1.html>.
-# #L%
-###
+#
+# Copyright (C) 2010 - 2014 JBoss by Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+#
 
 # Root logger option
 log4j.rootLogger=DEBUG, file, console

--- a/itests/basic/pom.xml
+++ b/itests/basic/pom.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-    limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/itests/basic/tomcat/pom.xml
+++ b/itests/basic/tomcat/pom.xml
@@ -1,18 +1,16 @@
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
   -->
 
 <!--

--- a/itests/basic/tomcat/src/test/java/io/fabric8/test/basic/tomcat/PortReplacementTest.java
+++ b/itests/basic/tomcat/src/test/java/io/fabric8/test/basic/tomcat/PortReplacementTest.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Gravia :: Runtime :: Embedded
- * %%
- * Copyright (C) 2013 - 2014 JBoss by Red Hat
- * %%
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,9 +11,8 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
+
 package io.fabric8.test.basic.tomcat;
 
 import java.io.FileInputStream;

--- a/itests/basic/tomcat/src/test/resources/arquillian.xml
+++ b/itests/basic/tomcat/src/test/resources/arquillian.xml
@@ -1,24 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  #%L
-  Gravia :: Integration Tests :: Tomcat
-  %%
-  Copyright (C) 2010 - 2013 JBoss by Red Hat
-  %%
-  This program is free software: you can redistribute it and/or modify
-  it under the terms of the GNU Lesser General Public License as 
-  published by the Free Software Foundation, either version 2.1 of the 
-  License, or (at your option) any later version.
-  
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Lesser Public License for more details.
-  
-  You should have received a copy of the GNU General Lesser Public 
-  License along with this program.  If not, see
-  <http://www.gnu.org/licenses/lgpl-2.1.html>.
-  #L%
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
   -->
 
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/itests/basic/tomcat/src/test/resources/logging.properties
+++ b/itests/basic/tomcat/src/test/resources/logging.properties
@@ -1,24 +1,17 @@
-###
-# #%L
-# JBossOSGi Resolver API
-# %%
-# Copyright (C) 2010 - 2013 JBoss by Red Hat
-# %%
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as 
-# published by the Free Software Foundation, either version 2.1 of the 
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Lesser Public License for more details.
-# 
-# You should have received a copy of the GNU General Lesser Public 
-# License along with this program.  If not, see
-# <http://www.gnu.org/licenses/lgpl-2.1.html>.
-# #L%
-###
+#
+# Copyright (C) 2010 - 2014 JBoss by Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+#
 
 # Root logger option
 log4j.rootLogger=DEBUG, file, console

--- a/itests/basic/tomcat/src/test/resources/server.xml
+++ b/itests/basic/tomcat/src/test/resources/server.xml
@@ -1,4 +1,19 @@
 <?xml version='1.0' encoding='utf-8'?>
+<!--
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  -->
+
 <Server port="8005" shutdown="SHUTDOWN">
     <Service name="Catalina">
         <Connector port="8080" protocol="HTTP/1.1" connectionTimeout="20000" redirectPort="8443" />

--- a/itests/basic/wildfly/pom.xml
+++ b/itests/basic/wildfly/pom.xml
@@ -1,18 +1,16 @@
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
   -->
 
 <!--

--- a/itests/basic/wildfly/src/test/resources/arquillian.xml
+++ b/itests/basic/wildfly/src/test/resources/arquillian.xml
@@ -1,24 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  #%L
-  Gravia :: Integration Tests :: WildFly
-  %%
-  Copyright (C) 2010 - 2013 JBoss by Red Hat
-  %%
-  This program is free software: you can redistribute it and/or modify
-  it under the terms of the GNU Lesser General Public License as 
-  published by the Free Software Foundation, either version 2.1 of the 
-  License, or (at your option) any later version.
-  
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Lesser Public License for more details.
-  
-  You should have received a copy of the GNU General Lesser Public 
-  License along with this program.  If not, see
-  <http://www.gnu.org/licenses/lgpl-2.1.html>.
-  #L%
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
   -->
 
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/itests/basic/wildfly/src/test/resources/logging.properties
+++ b/itests/basic/wildfly/src/test/resources/logging.properties
@@ -1,24 +1,17 @@
-###
-# #%L
-# JBossOSGi Resolver API
-# %%
-# Copyright (C) 2010 - 2013 JBoss by Red Hat
-# %%
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as 
-# published by the Free Software Foundation, either version 2.1 of the 
-# License, or (at your option) any later version.
-# 
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Lesser Public License for more details.
-# 
-# You should have received a copy of the GNU General Lesser Public 
-# License along with this program.  If not, see
-# <http://www.gnu.org/licenses/lgpl-2.1.html>.
-# #L%
-###
+#
+# Copyright (C) 2010 - 2014 JBoss by Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+#
 
 # Root logger option
 log4j.rootLogger=DEBUG, file, console

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -1,18 +1,16 @@
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/itests/smoke/pom.xml
+++ b/itests/smoke/pom.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-    limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,16 @@
 <!--
-  Copyright (C) FuseSource, Inc.
-  http://fusesource.com
+  Copyright (C) 2010 - 2014 JBoss by Red Hat
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">


### PR DESCRIPTION
Copyright seems to contain some gravia and fuse source references.
Also there are module references to the copyright which is both unusal, not supported by all IDEs and adds an extra maintenance cost. 

For cleaness shake I think that it should be good to have a more "standard" copyright format.
