### PR TITLE
Upgrade dependency plugin to the latest version

### DIFF
--- a/container/tomcat/distro/pom.xml
+++ b/container/tomcat/distro/pom.xml
@@ -50,6 +50,7 @@
         <finalName>fabric8-karaf</finalName>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <maven-assembly-plugin-version>2.4</maven-assembly-plugin-version>
         <maven-build-helper-plugin-version>1.8</maven-build-helper-plugin-version>
         <maven-bundle-plugin-version>2.3.4</maven-bundle-plugin-version>
+        <maven-dependency-plugin-version>2.8</maven-dependency-plugin-version>
         <maven-enforcer-plugin-version>1.3.1</maven-enforcer-plugin-version>
         <maven-notices-plugin-version>1.29</maven-notices-plugin-version>
         <maven-surefire-plugin-version>2.16</maven-surefire-plugin-version>
@@ -404,6 +405,11 @@
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
                     <version>${maven-bundle-plugin-version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency-plugin-version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
Using maven 3.0.5 on osx I am hitting an error in the maven dependency plugin.
Updating the plugin to version 2.8 fixes the issue.
