### PR TITLE
Add a nested profile builder inside the profile version builder

### DIFF
--- a/fabric/api/src/main/java/io/fabric8/api/CompositeBuilder.java
+++ b/fabric/api/src/main/java/io/fabric8/api/CompositeBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Fabric8 :: API
- * %%
- * Copyright (C) 2014 Red Hat
- * %%
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,22 +11,11 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
+
 package io.fabric8.api;
 
-import java.util.Map;
+public interface CompositeBuilder<P extends Builder>   {
 
-/**
- * A builder for an attributable object.
- *
- * @author thomas.diesler@jboss.com
- * @since 18-Apr-2014
- */
-public interface AttributableBuilder<B extends AttributableBuilder<B, T>, T> {
-
-    <V> B addAttribute(AttributeKey<V> key, V value);
-
-    B addAttributes(Map<AttributeKey<?>, Object> attributes);
+    P and();
 }

--- a/fabric/api/src/main/java/io/fabric8/api/NestedProfileBuilder.java
+++ b/fabric/api/src/main/java/io/fabric8/api/NestedProfileBuilder.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Fabric8 :: API
- * %%
- * Copyright (C) 2014 Red Hat
- * %%
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,22 +11,11 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
+
 package io.fabric8.api;
 
-import java.util.Map;
-
-/**
- * A builder for an attributable object.
- *
- * @author thomas.diesler@jboss.com
- * @since 18-Apr-2014
- */
-public interface AttributableBuilder<B extends AttributableBuilder<B, T>, T> {
-
-    <V> B addAttribute(AttributeKey<V> key, V value);
-
-    B addAttributes(Map<AttributeKey<?>, Object> attributes);
+public interface NestedProfileBuilder<P extends Builder> extends ProfileBuilderBase<NestedProfileBuilder<P>>,
+        AttributableBuilder<NestedProfileBuilder<P>, Profile>,
+        CompositeBuilder<P>  {
 }

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileBuilder.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileBuilder.java
@@ -21,8 +21,6 @@ package io.fabric8.api;
 
 import org.jboss.gravia.resource.Version;
 
-import java.util.Map;
-
 
 /**
  * A builder for a fabric profile
@@ -30,25 +28,8 @@ import java.util.Map;
  * @author thomas.diesler@jboss.com
  * @since 14-Mar-2014
  */
-public interface ProfileBuilder extends AttributableBuilder<ProfileBuilder, Profile> {
+public interface ProfileBuilder extends AttributableBuilder<ProfileBuilder, Profile>, ProfileBuilderBase<ProfileBuilder>, Builder<Profile> {
 
-    ProfileBuilder identity(String identity);
-
-    ProfileBuilder profileVersion(Version version);
-
-    ProfileBuilder fromOptionsProvider(ProfileOptionsProvider optionsProvider);
-
-    ProfileBuilder addProfileItem(ProfileItem item);
-
-    ProfileBuilder removeProfileItem(String identity);
-
-    ProfileBuilder addConfigurationItem(String identity, Map<String, Object> config);
-
-    ProfileBuilder removeConfigurationItem(String identity);
-
-    ProfileBuilder addParentProfile(String identity);
-
-    ProfileBuilder removeParentProfile(String identity);
 
     final class Factory {
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileBuilderBase.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileBuilderBase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+
+package io.fabric8.api;
+
+import org.jboss.gravia.resource.Version;
+
+import java.util.Map;
+
+public interface ProfileBuilderBase<B extends ProfileBuilderBase<B>> {
+
+    B identity(String identity);
+
+    B profileVersion(Version version);
+
+    B fromOptionsProvider(ProfileOptionsProvider optionsProvider);
+
+    B addProfileItem(ProfileItem item);
+
+    B removeProfileItem(String identity);
+
+    B addConfigurationItem(String identity, Map<String, Object> config);
+
+    B removeConfigurationItem(String identity);
+
+    B addParentProfile(String identity);
+
+    B removeParentProfile(String identity);
+}

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileItemBuilder.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileItemBuilder.java
@@ -28,5 +28,5 @@ package io.fabric8.api;
  * @author thomas.diesler@jboss.com
  * @since 14-Mar-2014
  */
-public interface ProfileItemBuilder<B extends ProfileItemBuilder<B, T>, T extends ProfileItem> extends AttributableBuilder<B, T> {
+public interface ProfileItemBuilder<B extends ProfileItemBuilder<B, T>, T extends ProfileItem> extends AttributableBuilder<B, T>, Builder<T> {
 }

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileVersionBuilder.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileVersionBuilder.java
@@ -27,17 +27,7 @@ import org.jboss.gravia.resource.Version;
  * @author thomas.diesler@jboss.com
  * @since 14-Mar-2014
  */
-public interface ProfileVersionBuilder extends AttributableBuilder<ProfileVersionBuilder, LinkedProfileVersion> {
-
-    ProfileVersionBuilder identity(Version version);
-
-    ProfileVersionBuilder fromOptionsProvider(ProfileVersionOptionsProvider optionsProvider);
-
-    ProfileBuilder getProfileBuilder(String identity);
-
-    ProfileVersionBuilder addProfile(Profile profile);
-
-    ProfileVersionBuilder removeProfile(String identity);
+public interface ProfileVersionBuilder extends ProfileVersionBuilderBase, AttributableBuilder<ProfileVersionBuilder, LinkedProfileVersion>, Builder<LinkedProfileVersion> {
 
     final class Factory {
 

--- a/fabric/api/src/main/java/io/fabric8/api/ProfileVersionBuilderBase.java
+++ b/fabric/api/src/main/java/io/fabric8/api/ProfileVersionBuilderBase.java
@@ -1,9 +1,6 @@
 /*
- * #%L
- * Fabric8 :: API
- * %%
- * Copyright (C) 2014 Red Hat
- * %%
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,22 +11,22 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
  */
+
 package io.fabric8.api;
 
-import java.util.Map;
+import org.jboss.gravia.resource.Version;
 
-/**
- * A builder for an attributable object.
- *
- * @author thomas.diesler@jboss.com
- * @since 18-Apr-2014
- */
-public interface AttributableBuilder<B extends AttributableBuilder<B, T>, T> {
+public interface ProfileVersionBuilderBase {
+    ProfileVersionBuilder identity(Version version);
 
-    <V> B addAttribute(AttributeKey<V> key, V value);
+    ProfileVersionBuilder fromOptionsProvider(ProfileVersionOptionsProvider optionsProvider);
 
-    B addAttributes(Map<AttributeKey<?>, Object> attributes);
+    ProfileBuilder getProfileBuilder(String identity);
+
+    NestedProfileBuilder<ProfileVersionBuilder> newProfile(String identity);
+
+    ProfileVersionBuilder addProfile(Profile profile);
+
+    ProfileVersionBuilder removeProfile(String identity);
 }

--- a/fabric/spi/src/main/java/io/fabric8/spi/AbstractContainerBuilder.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/AbstractContainerBuilder.java
@@ -19,11 +19,12 @@
  */
 package io.fabric8.spi;
 
+import io.fabric8.api.Builder;
 import io.fabric8.api.ContainerBuilder;
 import io.fabric8.api.CreateOptions;
 import io.fabric8.api.CreateOptionsProvider;
 
-public abstract class AbstractContainerBuilder<B extends ContainerBuilder<B, T>, T extends CreateOptions> extends AbstractAttributableBuilder<B, T> implements ContainerBuilder<B, T> {
+public abstract class AbstractContainerBuilder<B extends ContainerBuilder<B, T>, T extends CreateOptions> extends AbstractAttributableBuilder<B, T> implements ContainerBuilder<B, T>, Builder<T> {
 
     protected final T options;
 

--- a/fabric/spi/src/main/java/io/fabric8/spi/internal/DefaultProfileVersionBuilder.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/internal/DefaultProfileVersionBuilder.java
@@ -20,6 +20,7 @@
 package io.fabric8.spi.internal;
 
 import io.fabric8.api.LinkedProfileVersion;
+import io.fabric8.api.NestedProfileBuilder;
 import io.fabric8.api.Profile;
 import io.fabric8.api.ProfileBuilder;
 import io.fabric8.api.ProfileVersionBuilder;
@@ -59,6 +60,11 @@ final class DefaultProfileVersionBuilder extends AbstractAttributableBuilder<Pro
     public ProfileBuilder getProfileBuilder(String identity) {
         Profile linkedProfile = mutableVersion.getLinkedProfile(identity);
         return linkedProfile != null ? new DefaultProfileBuilder(linkedProfile) : new DefaultProfileBuilder(identity);
+    }
+
+    @Override
+    public NestedProfileBuilder newProfile(String identity) {
+        return new ProfileVersionNestedProfileBuilder(this, getProfileBuilder(identity));
     }
 
     @Override

--- a/fabric/spi/src/main/java/io/fabric8/spi/internal/ProfileVersionNestedProfileBuilder.java
+++ b/fabric/spi/src/main/java/io/fabric8/spi/internal/ProfileVersionNestedProfileBuilder.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2010 - 2014 JBoss by Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+
+package io.fabric8.spi.internal;
+
+import io.fabric8.api.AttributeKey;
+import io.fabric8.api.NestedProfileBuilder;
+import io.fabric8.api.ProfileBuilder;
+import io.fabric8.api.ProfileItem;
+import io.fabric8.api.ProfileOptionsProvider;
+import io.fabric8.api.ProfileVersionBuilder;
+import org.jboss.gravia.resource.Version;
+
+import java.util.Map;
+
+final class ProfileVersionNestedProfileBuilder implements NestedProfileBuilder<ProfileVersionBuilder> {
+
+    private final ProfileVersionBuilder parent;
+    private final ProfileBuilder nested;
+
+    public ProfileVersionNestedProfileBuilder(ProfileVersionBuilder parent, ProfileBuilder nested) {
+        this.parent = parent;
+        this.nested = nested;
+    }
+
+    @Override
+    public ProfileVersionBuilder and() {
+        parent.addProfile(nested.build());
+        return parent;
+    }
+
+    @Override
+    public ProfileVersionNestedProfileBuilder identity(String identity) {
+         nested.identity(identity);
+         return this;
+    }
+
+    @Override
+    public ProfileVersionNestedProfileBuilder profileVersion(Version version) {
+        nested.profileVersion(version);
+        return this;
+    }
+
+    @Override
+    public ProfileVersionNestedProfileBuilder fromOptionsProvider(ProfileOptionsProvider optionsProvider) {
+        nested.fromOptionsProvider(optionsProvider);
+        return this;
+    }
+
+    @Override
+    public ProfileVersionNestedProfileBuilder addProfileItem(ProfileItem item) {
+         nested.addProfileItem(item);
+        return this;
+    }
+
+    @Override
+    public ProfileVersionNestedProfileBuilder removeProfileItem(String identity) {
+        nested.removeProfileItem(identity);
+        return this;
+    }
+
+    @Override
+    public ProfileVersionNestedProfileBuilder addConfigurationItem(String identity, Map<String, Object> config) {
+        nested.addConfigurationItem(identity, config);
+        return this;
+    }
+
+    @Override
+    public ProfileVersionNestedProfileBuilder removeConfigurationItem(String identity) {
+        nested.removeConfigurationItem(identity);
+        return this;
+    }
+
+    @Override
+    public ProfileVersionNestedProfileBuilder addParentProfile(String identity) {
+        nested.addParentProfile(identity);
+        return this;
+    }
+
+    @Override
+    public ProfileVersionNestedProfileBuilder removeParentProfile(String identity) {
+        nested.removeParentProfile(identity);
+        return this;
+    }
+
+    @Override
+    public ProfileVersionNestedProfileBuilder addAttributes(Map<AttributeKey<?>, Object> attributes) {
+        nested.addAttributes(attributes);
+        return this;
+    }
+
+    @Override
+    public <V> ProfileVersionNestedProfileBuilder addAttribute(AttributeKey<V> key, V value) {
+        nested.addAttribute(key, value);
+        return this;
+    }
+}

--- a/itests/smoke/common/src/main/java/io/fabric8/test/smoke/ConcurrentProfileTestBase.java
+++ b/itests/smoke/common/src/main/java/io/fabric8/test/smoke/ConcurrentProfileTestBase.java
@@ -20,7 +20,6 @@
 package io.fabric8.test.smoke;
 
 import io.fabric8.api.ConfigurationProfileItem;
-import io.fabric8.api.ConfigurationProfileItemBuilder;
 import io.fabric8.api.Container;
 import io.fabric8.api.ContainerIdentity;
 import io.fabric8.api.ContainerManager;
@@ -89,19 +88,16 @@ public abstract class ConcurrentProfileTestBase {
 
         // Build a profile version with two profiles
         // A <= B
-        ProfileVersionBuilder vsnBuilder = ProfileVersionBuilder.Factory.create(version);
 
-        ProfileVersion profileVersion =  vsnBuilder
-                .addProfile(
-                        vsnBuilder.getProfileBuilder("prfA")
-                                .addConfigurationItem(PID,Collections.singletonMap("keyA", (Object) new Integer(0)))
-                                .build())
-                .addProfile(
-                        vsnBuilder.getProfileBuilder("prfB")
-                                .addParentProfile("prfA")
-                                .addConfigurationItem(PID, Collections.singletonMap("keyB", (Object) new Integer(0)))
-                        .build()
-                ).build();
+        ProfileVersion profileVersion = ProfileVersionBuilder.Factory.create(version)
+                .newProfile("prfA")
+                    .addConfigurationItem(PID, Collections.singletonMap("keyA", (Object) new Integer(0)))
+                .and()
+                .newProfile("prfB")
+                    .addParentProfile("prfA")
+                .addConfigurationItem(PID, Collections.singletonMap("keyB", (Object) new Integer(0)))
+                .and()
+                .build();
 
         // Add the profile version
         ProfileManager prfManager = ProfileManagerLocator.getProfileManager();

--- a/itests/smoke/common/src/main/java/io/fabric8/test/smoke/ProfileUpdateTestBase.java
+++ b/itests/smoke/common/src/main/java/io/fabric8/test/smoke/ProfileUpdateTestBase.java
@@ -24,7 +24,6 @@ import static io.fabric8.api.Constants.DEFAULT_PROFILE_VERSION;
 import io.fabric8.api.ComponentEvent;
 import io.fabric8.api.ComponentEventListener;
 import io.fabric8.api.ConfigurationProfileItem;
-import io.fabric8.api.ConfigurationProfileItemBuilder;
 import io.fabric8.api.Container;
 import io.fabric8.api.Container.State;
 import io.fabric8.api.ContainerIdentity;
@@ -85,13 +84,11 @@ public abstract class ProfileUpdateTestBase  {
         final String identity = "foo";
 
         // Build a profile version
-        ProfileVersionBuilder versionBuilder = ProfileVersionBuilder.Factory.create(version12);
-        ProfileVersion profileVersion = versionBuilder.addProfile(
-                versionBuilder.getProfileBuilder(identity)
-                        .addConfigurationItem("some.pid", Collections.singletonMap("xxx", (Object) "yyy"))
-                        .build()
-
-        ).build();
+        ProfileVersion profileVersion = ProfileVersionBuilder.Factory.create(version12)
+                .newProfile(identity)
+                .addConfigurationItem("some.pid", Collections.singletonMap("xxx", (Object) "yyy"))
+                .and()
+                .build();
 
         // Add a profile version
         ProfileManager prfManager = ProfileManagerLocator.getProfileManager();

--- a/itests/smoke/embedded/src/test/java/io/fabric8/test/smoke/embedded/EffectiveProfileTest.java
+++ b/itests/smoke/embedded/src/test/java/io/fabric8/test/smoke/embedded/EffectiveProfileTest.java
@@ -20,10 +20,8 @@
 package io.fabric8.test.smoke.embedded;
 
 import io.fabric8.api.ConfigurationProfileItem;
-import io.fabric8.api.ConfigurationProfileItemBuilder;
 import io.fabric8.api.LinkedProfile;
 import io.fabric8.api.Profile;
-import io.fabric8.api.ProfileBuilder;
 import io.fabric8.api.ProfileManager;
 import io.fabric8.api.ProfileManagerLocator;
 import io.fabric8.api.ProfileVersion;
@@ -86,24 +84,22 @@ public class EffectiveProfileTest {
     @Test
     public void testEffectiveProfile() {
 
-        ProfileVersionBuilder versionBuilder = ProfileVersionBuilder.Factory.create(version);
-
-        ProfileVersion linkedVersion = versionBuilder
-                .addProfile(versionBuilder.getProfileBuilder(identityA)
+        ProfileVersion linkedVersion = ProfileVersionBuilder.Factory.create(version)
+                .newProfile(identityA)
                         .addConfigurationItem("confItem", configA)
                         .addConfigurationItem("confItemA", configA)
-                        .build())
-                .addProfile(versionBuilder.getProfileBuilder(identityB)
+                        .and()
+                .newProfile(identityB)
                         .addParentProfile(identityA)
                         .addConfigurationItem("confItem", configB)
                         .addConfigurationItem("confItemB", configB)
-                        .build())
-                .addProfile(versionBuilder.getProfileBuilder(identityC)
+                        .and()
+                .newProfile(identityC)
                         .addParentProfile(identityA)
                         .addParentProfile(identityB)
                         .addConfigurationItem("confItem", configC)
                         .addConfigurationItem("confItemC", configC)
-                        .build())
+                        .and()
                 .build();
 
 

--- a/itests/smoke/embedded/src/test/java/io/fabric8/test/smoke/embedded/LinkedProfileTest.java
+++ b/itests/smoke/embedded/src/test/java/io/fabric8/test/smoke/embedded/LinkedProfileTest.java
@@ -20,11 +20,7 @@
 package io.fabric8.test.smoke.embedded;
 
 import io.fabric8.api.ConfigurationProfileItem;
-import io.fabric8.api.ConfigurationProfileItemBuilder;
 import io.fabric8.api.LinkedProfile;
-import io.fabric8.api.LinkedProfileVersion;
-import io.fabric8.api.Profile;
-import io.fabric8.api.ProfileBuilder;
 import io.fabric8.api.ProfileManager;
 import io.fabric8.api.ProfileManagerLocator;
 import io.fabric8.api.ProfileVersion;
@@ -86,23 +82,22 @@ public class LinkedProfileTest {
     @Test
     public void testLinkedProfile() {
 
-        ProfileVersionBuilder versionBuilder = ProfileVersionBuilder.Factory.create(version);
-        ProfileVersion linkedVersion = versionBuilder
-                .addProfile(versionBuilder.getProfileBuilder(identityA)
-                        .addConfigurationItem("confItem", configA)
-                        .addConfigurationItem("confItemA", configA)
-                        .build())
-                .addProfile(versionBuilder.getProfileBuilder(identityB)
-                        .addParentProfile(identityA)
-                        .addConfigurationItem("confItem", configB)
-                        .addConfigurationItem("confItemB", configB)
-                        .build())
-                .addProfile(versionBuilder.getProfileBuilder(identityC)
-                        .addParentProfile(identityA)
-                        .addParentProfile(identityB)
-                        .addConfigurationItem("confItem", configC)
-                        .addConfigurationItem("confItemC", configC)
-                        .build())
+        ProfileVersion linkedVersion = ProfileVersionBuilder.Factory.create(version)
+                .newProfile(identityA)
+                .addConfigurationItem("confItem", configA)
+                .addConfigurationItem("confItemA", configA)
+                .and()
+                .newProfile(identityB)
+                .addParentProfile(identityA)
+                .addConfigurationItem("confItem", configB)
+                .addConfigurationItem("confItemB", configB)
+                .and()
+                .newProfile(identityC)
+                .addParentProfile(identityA)
+                .addParentProfile(identityB)
+                .addConfigurationItem("confItem", configC)
+                .addConfigurationItem("confItemC", configC)
+                .and()
                 .build();
 
         ProfileManager prfManager = ProfileManagerLocator.getProfileManager();

--- a/itests/smoke/embedded/src/test/java/io/fabric8/test/smoke/embedded/LinkedProfileVersionTest.java
+++ b/itests/smoke/embedded/src/test/java/io/fabric8/test/smoke/embedded/LinkedProfileVersionTest.java
@@ -20,10 +20,8 @@
 package io.fabric8.test.smoke.embedded;
 
 import io.fabric8.api.ConfigurationProfileItem;
-import io.fabric8.api.ConfigurationProfileItemBuilder;
 import io.fabric8.api.LinkedProfileVersion;
 import io.fabric8.api.Profile;
-import io.fabric8.api.ProfileBuilder;
 import io.fabric8.api.ProfileManager;
 import io.fabric8.api.ProfileManagerLocator;
 import io.fabric8.api.ProfileVersion;
@@ -86,24 +84,24 @@ public class LinkedProfileVersionTest {
     @Test
     public void testLinkedProfileVersion() {
 
-        ProfileVersionBuilder versionBuilder = ProfileVersionBuilder.Factory.create(version);
-        LinkedProfileVersion linkedVersion = versionBuilder
-                .addProfile(versionBuilder.getProfileBuilder(identityA)
-                        .addConfigurationItem("confItem", configA)
-                        .addConfigurationItem("confItemA", configA)
-                        .build())
-                .addProfile(versionBuilder.getProfileBuilder(identityB)
-                        .addParentProfile(identityA)
-                        .addConfigurationItem("confItem", configB)
-                        .addConfigurationItem("confItemB", configB)
-                        .build())
-                .addProfile(versionBuilder.getProfileBuilder(identityC)
-                        .addParentProfile(identityA)
-                        .addParentProfile(identityB)
-                        .addConfigurationItem("confItem", configC)
-                        .addConfigurationItem("confItemC", configC)
-                        .build())
+        LinkedProfileVersion linkedVersion = ProfileVersionBuilder.Factory.create(version)
+                .newProfile(identityA)
+                .addConfigurationItem("confItem", configA)
+                .addConfigurationItem("confItemA", configA)
+                .and()
+                .newProfile(identityB)
+                .addParentProfile(identityA)
+                .addConfigurationItem("confItem", configB)
+                .addConfigurationItem("confItemB", configB)
+                .and()
+                .newProfile(identityC)
+                .addParentProfile(identityA)
+                .addParentProfile(identityB)
+                .addConfigurationItem("confItem", configC)
+                .addConfigurationItem("confItemC", configC)
+                .and()
                 .build();
+
         Set<String> profileIdentities = linkedVersion.getProfileIdentities();
         Assert.assertEquals(3, profileIdentities.size());
         Assert.assertTrue(profileIdentities.contains(identityA));


### PR DESCRIPTION
Currently the ProfileVersionBuilder is able to create a ProfileBuilder which the user can use to create profile and add them to the version, like the snippet below:

``` java
ProfileVersionBuilder versionBuilder = ProfileVersionBuilder.Factory.create(version);
ProfileVersion linkedVersion = versionBuilder
                 .addProfile(versionBuilder.getProfileBuilder(identityA)
                         .addConfigurationItem("confItem", configA)
                         .build())
                 .addProfile(versionBuilder.getProfileBuilder(identityB)
                         .addParentProfile(identityA)
                         .addConfigurationItem("confItem", configB)
                         .build())
                 .build()
```

We could remove the need of carrying around the version builder instance by allowing the ProfileVersionBuilder to use a nested profile builder. The snippet above could become:

``` java
ProfileVersion linkedVersion = ProfileVersionBuilder.Factory.create(version)
                 .withProfile(identityA)
                         .addConfigurationItem("confItem", configA)
                  .and()
                 . withProfile(identityB)
                         .addParentProfile(identityA)
                         .addConfigurationItem("confItem", configB)
                  .and()
                 .build()
```

This is a small improvement in terms of cleaness, but does remove the burden of having to keep track which are the builder ones need to hold a reference to.

This PR adds the concept of composite/nested builder and applies it in the example above.
